### PR TITLE
Adding /etc/default/kafka for environment variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,8 @@ kafka_generate_broker_id: yes
 
 kafka_log4j_date_pattern: "'.'yyyy-MM-dd" # Rollover at midnight each day.
 
+kafka_environment: {}
+
 server:
   # broker_id: <-- this is auto-set by hashing the machine-id during kafka-cfg step.
   # zookeeper_hosts: <-- this is auto-set by the global "zookeeper_hosts" setting.
@@ -52,6 +54,8 @@ server:
   host_name:
   advertised_host_name:
   advertised_port:
+  advertised_listeners:
+  listeners:
   socket_send_buffer_bytes: 102400
   socket_receive_buffer_bytes: 102400
   socket_request_max_bytes: 104857600
@@ -143,4 +147,3 @@ producer:
   queue_buffering_max_messages:
   queue_enqueue_timeout_ms:
   batch_num_messages:
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,11 @@ kafka_generate_broker_id: yes
 
 kafka_log4j_date_pattern: "'.'yyyy-MM-dd" # Rollover at midnight each day.
 
+
 kafka_environment: {}
+
+healthcheck_address: "{{ server.host_name | default('127.0.0.1')}}"
+
 
 server:
   # broker_id: <-- this is auto-set by hashing the machine-id during kafka-cfg step.

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -48,7 +48,7 @@
     - kafka-cfg
 
 - name: "Wait for kafka to come up and open it's server port"
-  wait_for: port={{ server.port }} host=127.0.0.1 connect_timeout={{ kafka_port_test_timeout_seconds }} timeout={{ kafka_port_test_timeout_seconds }}
+  wait_for: port={{ server.port }} host={{ healthcheck_address }} connect_timeout={{ kafka_port_test_timeout_seconds }} timeout={{ kafka_port_test_timeout_seconds }}
   ignore_errors: yes
   register: healthcheck
   tags:

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -29,6 +29,14 @@
   tags:
     - kafka-cfg
 
+- name: "Render and write out kafka user env file"
+  template: src=etc/defaults/kafka.j2 dest="/etc/default/kafka" mode=0644 owner=root group=root
+  sudo: yes
+  notify:
+    - restart kafka
+  tags:
+    - kafka-cfg
+
 - name: "Link alternate logs directory and touch output files"
   shell: "( test ! -e /usr/local/kafka/logs || rm -rf /usr/local/kafka/logs ) && ln -s /var/log/kafka /usr/local/kafka/logs && touch /var/log/kafka/state-change.log /var/log/kafka/kafkaServer.out && chown kafka:kafka /var/log/kafka/state-change.log /var/log/kafka/kafkaServer.out"
   changed_when: False
@@ -53,4 +61,3 @@
   tags:
     - kafka-cfg
     - kafka-healthcheck
-

--- a/templates/etc/defaults/kafka.j2
+++ b/templates/etc/defaults/kafka.j2
@@ -1,0 +1,6 @@
+KAFKA_HEAP_OPTS='{{ kafka_heap_opts }}'
+LOG_DIR=${LOG_DIR}
+
+{% for key, value in kafka_environment.iteritems() %}
+{{key}}={{value}}
+{% endfor %}

--- a/templates/etc/init/kafka.conf.j2
+++ b/templates/etc/init/kafka.conf.j2
@@ -18,12 +18,14 @@ env STDERR={{ kafka_log_dir }}/kafka.err
 env PID=/var/run/kafka.pid
 
 script
+    KAFKA_OPTS=$(tr '\n' ' ' < /etc/default/kafka)
+
     test -d "${LOG_DIR}" || mkdir -p "${LOG_DIR}"
     chown -R "${USER}:${GROUP}" "${LOG_DIR}"
     echo $$ > "${PID}"
     sudo su $USER --shell /bin/sh -c 'echo "start inititated, ulimit -n => $(ulimit -n)"'" 1>>${STDOUT} 2>>${STDERR}"
     # Rather than using setuid/setgid sudo is used because the pre-start task must run as root.
-    exec sudo --set-home --user="${USER}" --group="${GROUP}" /bin/sh -c "KAFKA_HEAP_OPTS='{{ kafka_heap_opts }}' LOG_DIR=${LOG_DIR} /usr/local/kafka/bin/kafka-server-start.sh {{ kafka_conf_dir }}/server.properties 1>>${STDOUT} 2>>${STDERR}"
+    exec sudo --set-home --user="${USER}" --group="${GROUP}" /bin/sh -c "${KAFKA_OPTS} /usr/local/kafka/bin/kafka-server-start.sh {{ kafka_conf_dir }}/server.properties 1>>${STDOUT} 2>>${STDERR}"
 end script
 
 post-stop script

--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -27,6 +27,9 @@ log.dirs={{ server.log_dirs }}
 {% if server.port %}
 # default: 9092
 # The port on which the server accepts client connections.
+#
+# Kafka 0.10.0
+# DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. the port to listen and accept connections on
 port={{ server.port }}
 {% endif %}
 
@@ -58,21 +61,42 @@ background.threads={{ server.background_threads }}
 queued.max.requests={{ server.queued_max_requests }}
 {% endif %}
 
+{% if server.listeners %}
+# default: null
+# Listener List - Comma-separated list of URIs we will listen on and their protocols. Specify hostname as 0.0.0.0 to bind to all interfaces. Leave hostname empty to bind to default interface. Examples of legal listener lists: PLAINTEXT://myhost:9092,TRACE://:9091 PLAINTEXT://0.0.0.0:9092, TRACE://localhost:9093
+listeners={{ server.listeners }}
+{% endif %}
+
+{% if server.advertised_listeners %}
+# default: null
+# Listeners to publish to ZooKeeper for clients to use, if different than the listeners above. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used.
+advertised_listeners={{ server.advertised_listeners }}
+{% endif %}
+
 {% if server.host_name %}
 # default: null
 # Hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces, and publish one to ZK.
+#
+# Kafka 0.10.0
+# DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces
 host.name={{ server.host_name }}
 {% endif %}
 
 {% if server.advertised_host_name %}
 # default: null
 # If this is set this is the hostname that will be given out to producers, consumers, and other brokers to connect to.
+#
+# Kafka 0.10.0
+# DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
 advertised.host.name={{ server.advertised_host_name }}
 {% endif %}
 
 {% if server.advertised_port %}
 # default: null
 # The port to give out to producers, consumers, and other brokers to use in establishing connections. This only needs to be set if this port is different from the port the server should bind to.
+#
+# Kafka 0.10.0
+# DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. The port to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
 advertised.port={{ server.advertised_port }}
 {% endif %}
 


### PR DESCRIPTION
This pull request allows you to set environment variables for things like JMX monitoring.

Turn on monitoring with the following

```
kafka_environment:
  JMX_PORT: 9999
```

Also, I've added a few of the config changes for kafka 0.10.0.0
