### PR TITLE
Log and config convenience options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,15 @@ Example:
       roles:
         - {
           role: "ansible-kafka",
-          kafka_hosts: "{{ groups.kafka | join(':9092,') }}:9092",
-          zookeeper_hosts: "{{ zookeeper_hosts }}"
+          kafka_hosts: "{{ groups.kafka | list }}",
+          zookeeper_hosts: "{{ zookeeper_hosts | list }}"
           kafka_version: 0.8.2.1,     # Kafka version override.
           kafka_scala_serverion: 2.10 # Scala version override.
         }
 ```
 
 Where `kafka_hosts` and `zookeeper_hosts` are both defined variables
-(e.g. in group_vars/all), and contain comma-delimited lists of host:port pairs.
-
-Example host:port pair format:
-
-    host1:port,host2:port,...,hostN:port
+(e.g. in group_vars/all), and contain the list of hosts to use.
 
 ## Important Note
 
@@ -67,4 +63,3 @@ BSD
 Jay Taylor
 
 [@jtaylor](https://twitter.com/jtaylor) - [jaytaylor.com](http://jaytaylor.com) - [github](https://github.com/jaytaylor)
-

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example:
         - {
           role: "ansible-kafka",
           kafka_hosts: "{{ groups.kafka | list }}",
-          zookeeper_hosts: "{{ zookeeper_hosts | list }}"
+          kafka_zookeeper_hosts: "{{ zookeeper_hosts | list }}"
           kafka_version: 0.8.2.1,     # Kafka version override.
           kafka_scala_serverion: 2.10 # Scala version override.
         }
@@ -49,8 +49,8 @@ If you are using this role from the ansible-galaxy website, make sure you use "j
 
 ## Role variables
 
-- `kafka_hosts` - Comma separated list of host:port pairs in the cluster, defaults to 'ansible_fqdn:9092' for a single node.
-- `zookeeper_hosts` - Comma separated list of host:port pairs.
+- `kafka_hosts` - list of hosts in the cluster.
+- `kafka_zookeeper_hosts` - list of zookeeper hosts for the cluster.
 - `kafka_broker_id` - Integer uniquely identifying the broker, by default one will be generated for you either by this role or by kafka itself for versions >= 0.9.
 - `kafka_generate_broker_id` - Flag controlling whether to generate a broker id, defaults to `yes`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-zookeeper_hosts: # <-- must be overridden further up the chain
+kafka_zookeeper_hosts: # <-- must be overridden further up the chain
 # e.g. [ 'srvr1', 'srvr2' ]
-zookeeper_port: 2181
+kafka_zookeeper_port: 2181
 
 kafka_hosts: # <-- must be overridden further up the chain
 # e.g. [ 'srvr1', 'srvr2' ]
@@ -54,7 +54,7 @@ healthcheck_address: "{{ server.host_name | default('127.0.0.1')}}"
 
 server:
   # broker_id: <-- this is auto-set by hashing the machine-id during kafka-cfg step.
-  # zookeeper_hosts: <-- this is auto-set by the global "zookeeper_hosts" setting.
+  # zookeeper_hosts: <-- this is auto-set by the global "kafka_zookeeper_hosts" setting.
   log_dirs: "{{ kafka_data_dir }}"
   port: 9092
   message_max_bytes:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,12 @@ kafka_user: kafka
 
 kafka_max_logfile_size: 50MB
 kafka_max_logbackup_idx: 7
+kafka_logger_root: INFO, stdout
+kafka_logger_kafka: INFO, kafkaAppender
+kafka_logger_kafka_controller: TRACE, controllerAppender
+kafka_logger_kafka_request: WARN, requestAppender
+kafka_logger_kafka_cleaner: INFO, cleanerAppender
+kafka_logger_state: TRACE, stateChangeAppender
 
 kafka_heap_opts: "-Xmx1G -Xms1G"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,6 +132,7 @@ server:
   offsets_load_buffer_size:
   offsets_commit_required_acks:
   offsets_commit_timeout_ms:
+  misc: {}
 
 producer:
   # metadata_broker_list: <-- this is auto-set by the global "kafka_hosts" setting.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 zookeeper_hosts: # <-- must be overridden further up the chain
-# e.g. srvr1:2181,srvr2:2181
+# e.g. [ 'srvr1', 'srvr2' ]
+zookeeper_port: 2181
 
 kafka_hosts: # <-- must be overridden further up the chain
-# e.g. srvr1:9092,srvr2:9092
+# e.g. [ 'srvr1', 'srvr2' ]
 
 kafka_version: "0.9.0.1"
 

--- a/tasks/check-env.yml
+++ b/tasks/check-env.yml
@@ -1,7 +1,8 @@
 ---
-- name: "Check 'zookeeper_hosts' variable"
-  fail: msg="Playbook execution aborted due to missing or empty required variable 'zookeeper_hosts'"
-  when: zookeeper_hosts is not defined or zookeeper_hosts == ''
+
+- name: "Check 'kafka_zookeeper_hosts' variable"
+  fail: msg="Playbook execution aborted due to missing or empty required variable 'kafka_zookeeper_hosts'"
+  when: kafka_zookeeper_hosts is not defined or kafka_zookeeper_hosts | length == 0
   tags:
     - kafka-install
     - kafka-cfg
@@ -17,5 +18,5 @@
   fail: msg="Playbook execution aborted because when 'kafka_version' < '0.9.0.0' either 'kafka_broker_id' must be defined or 'kafka_generate_broker_id' enabled"
   when: >
     not kafka_generate_broker_id | bool and
-    kafka_broker_id is not defined and 
+    kafka_broker_id is not defined and
     kafka_version | version_compare('0.9.0.0', '<')

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -17,7 +17,7 @@
   when: kafka_generate_broker_id | bool and kafka_version | version_compare('0.9.0.0', '>=')
 
 - name: "Generate the zookeeper hosts connection string"
-  set_fact: zookeeper_connection_string="{{ zookeeper_hosts | join(':' ~ zookeeper_port ~ ',') }}:{{ zookeeper_port }}"
+  set_fact: zookeeper_connection_string="{{ kafka_zookeeper_hosts | join(':' ~ zookeeper_port ~ ',') }}:{{ zookeeper_port }}"
 
 - name: "Generate the kafka hosts connection string"
   set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ server.port ~ ',') }}:{{ server.port }}"

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -43,6 +43,12 @@
   tags:
     - kafka-cfg
 
+- name: "Enable kafka system service"
+  service: name=kafka state=started enabled=yes
+  sudo: yes
+  tags:
+    - kafka-install
+
 - name: "Link alternate logs directory and touch output files"
   shell: "( test ! -e /usr/local/kafka/logs || rm -rf /usr/local/kafka/logs ) && ln -s /var/log/kafka /usr/local/kafka/logs && touch /var/log/kafka/state-change.log /var/log/kafka/kafkaServer.out && chown kafka:kafka /var/log/kafka/state-change.log /var/log/kafka/kafkaServer.out"
   changed_when: False

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -16,6 +16,12 @@
   set_fact: kafka_reserved_broker_max_id=1000000000
   when: kafka_generate_broker_id | bool and kafka_version | version_compare('0.9.0.0', '>=')
 
+- name: "Generate the kafka hosts connection string"
+  set_fact: zookeeper_connection_string="{{ zookeeper_hosts | join(':' ~ zookeeper_port ~ ',') }}:{{ zookeeper_port }}"
+
+- name: "Generate the zookeeper hosts connection string"
+  set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ server.port ~ ',') }}:{{ server.port }}"
+
 - name: "Render and write out kafka configuration files"
   template: src=usr/local/kafka/config/{{ item }}.j2 dest="{{ kafka_conf_dir }}/{{ item }}" mode=0640 owner={{ kafka_user }} group={{ kafka_group }}
   sudo: yes

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -63,7 +63,7 @@
 
 - name: "Check kafka port test result"
   fail: msg="Kafka port not open on host={{ inventory_hostname }}, port={{ server.port }}"
-  when: healthcheck.elapsed >= kafka_port_test_timeout_seconds
+  when: healthcheck.elapsed >= kafka_port_test_timeout_seconds and kafka_port_test_timeout_seconds > 0
   tags:
     - kafka-cfg
     - kafka-healthcheck

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -16,10 +16,10 @@
   set_fact: kafka_reserved_broker_max_id=1000000000
   when: kafka_generate_broker_id | bool and kafka_version | version_compare('0.9.0.0', '>=')
 
-- name: "Generate the kafka hosts connection string"
+- name: "Generate the zookeeper hosts connection string"
   set_fact: zookeeper_connection_string="{{ zookeeper_hosts | join(':' ~ zookeeper_port ~ ',') }}:{{ zookeeper_port }}"
 
-- name: "Generate the zookeeper hosts connection string"
+- name: "Generate the kafka hosts connection string"
   set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ server.port ~ ',') }}:{{ server.port }}"
 
 - name: "Render and write out kafka configuration files"

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -17,7 +17,7 @@
   when: kafka_generate_broker_id | bool and kafka_version | version_compare('0.9.0.0', '>=')
 
 - name: "Generate the zookeeper hosts connection string"
-  set_fact: zookeeper_connection_string="{{ kafka_zookeeper_hosts | join(':' ~ zookeeper_port ~ ',') }}:{{ zookeeper_port }}"
+  set_fact: zookeeper_connection_string="{{ kafka_zookeeper_hosts | join(':' ~ kafka_zookeeper_port ~ ',') }}:{{ kafka_zookeeper_port }}"
 
 - name: "Generate the kafka hosts connection string"
   set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ server.port ~ ',') }}:{{ server.port }}"

--- a/tasks/kafka-install.yml
+++ b/tasks/kafka-install.yml
@@ -104,10 +104,3 @@
   sudo: yes
   tags:
     - kafka-install
-
-- name: "Enable kafka system service"
-  service: name=kafka state=started enabled=yes
-  sudo: yes
-  tags:
-    - kafka-install
-

--- a/templates/etc/defaults/kafka.j2
+++ b/templates/etc/defaults/kafka.j2
@@ -1,5 +1,5 @@
 KAFKA_HEAP_OPTS='{{ kafka_heap_opts }}'
-LOG_DIR=${LOG_DIR}
+LOG_DIR='{{ kafka_log_dir }}'
 
 {% for key, value in kafka_environment.iteritems() %}
 {{key}}={{value}}

--- a/templates/etc/systemd/system/kafka.service.j2
+++ b/templates/etc/systemd/system/kafka.service.j2
@@ -8,9 +8,8 @@ User=kafka
 Group=kafka
 LimitNOFILE={{ nofiles_limit }}
 Restart=on-failure
-Environment="KAFKA_HEAP_OPTS={{ kafka_heap_opts }}"
+EnvironmentFile=/etc/default/kafka
 ExecStart=/usr/local/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
 
 [Install]
 WantedBy=multi-user.target
-

--- a/templates/usr/local/kafka/config/consumer.properties.j2
+++ b/templates/usr/local/kafka/config/consumer.properties.j2
@@ -1,10 +1,9 @@
 # consumer.properties.j2
 
-zookeeper.connect={{ zookeeper_hosts }}
+zookeeper.connect={{ zookeeper_connection_string }}
 
 # timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=6000
 
 # consumer group id
 group.id=my-consumer-group
-

--- a/templates/usr/local/kafka/config/log4j.properties.j2
+++ b/templates/usr/local/kafka/config/log4j.properties.j2
@@ -15,7 +15,7 @@
 
 kafka.logs.dir={{ kafka_log_dir }}
 
-log4j.rootLogger=INFO, stdout 
+log4j.rootLogger={{ kafka_logger_root }}
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -68,7 +68,7 @@ log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 #log4j.logger.kafka.perf=DEBUG, kafkaAppender
 #log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaAppender
 #log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG
-log4j.logger.kafka=INFO, kafkaAppender
+log4j.logger.kafka={{ kafka_logger_kafka }}
 
 log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
 log4j.additivity.kafka.network.RequestChannel$=false
@@ -76,15 +76,14 @@ log4j.additivity.kafka.network.RequestChannel$=false
 #log4j.logger.kafka.network.Processor=TRACE, requestAppender
 #log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
 #log4j.additivity.kafka.server.KafkaApis=false
-log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.logger.kafka.request.logger={{ kafka_logger_kafka_request }}
 log4j.additivity.kafka.request.logger=false
 
-log4j.logger.kafka.controller=TRACE, controllerAppender
+log4j.logger.kafka.controller={{ kafka_logger_kafka_controller }}
 log4j.additivity.kafka.controller=false
 
-log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
+log4j.logger.kafka.log.LogCleaner={{ kafka_logger_kafka_cleaner }}
 log4j.additivity.kafka.log.LogCleaner=false
 
-log4j.logger.state.change.logger=TRACE, stateChangeAppender
+log4j.logger.state.change.logger={{ kafka_logger_state }}
 log4j.additivity.state.change.logger=false
-

--- a/templates/usr/local/kafka/config/producer.properties.j2
+++ b/templates/usr/local/kafka/config/producer.properties.j2
@@ -18,7 +18,7 @@
 
 # list of brokers used for bootstrapping knowledge about the rest of the cluster
 # format: host1:port1,host2:port2 ...
-metadata.broker.list={{ kafka_hosts }}
+metadata.broker.list={{ kafka_connection_string }}
 
 {% if producer %}
 

--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -14,7 +14,7 @@ reserved.broker.max.id={{ kafka_reserved_broker_max_id }}
 
 # default: null
 # Specifies the ZooKeeper connection string in the form hostname:port, where hostname and port are the host and port for a node in your ZooKeeper cluster. To allow connecting through other ZooKeeper nodes when that host is down you can also specify multiple hosts in the form hostname1:port1,hostname2:port2,hostname3:port3.  ZooKeeper also allows you to add a "chroot" path which will make all kafka data for this cluster appear under a particular path. This is a way to setup multiple Kafka clusters or other applications on the same ZooKeeper cluster. To do this give a connection string in the form hostname1:port1,hostname2:port2,hostname3:port3/chroot/path which would put all this cluster's data under the path /chroot/path. Note that you must create this path yourself prior to starting the broker and consumers must use the same connection string.
-zookeeper.connect={{ zookeeper_hosts }}
+zookeeper.connect={{ zookeeper_connection_string }}
 
 {% if server %}
 

--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -516,3 +516,7 @@ offsets.commit.timeout.ms={{ server.offsets_commit_timeout_ms }}
 {% endif %}
 
 {% endif %}
+
+{% for key, value in server.misc.iteritems() -%}
+{{key}}={{value}}
+{% endfor -%}

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -2,8 +2,10 @@
 
 - hosts: localhost
   vars:
-    zookeeper_hosts: "localhost:2181"
-    kafka_hosts: "localhost:9092"
+    zookeeper_hosts:
+      - localhost
+    kafka_hosts:
+      - localhost
   roles:
   - zookeeper
   - ansible-kafka

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -2,7 +2,8 @@
 
 - hosts: localhost
   vars:
-    zookeeper_hosts:
+    zookeeper_hosts: localhost:2181
+    kafka_zookeeper_hosts:
       - localhost
     kafka_hosts:
       - localhost


### PR DESCRIPTION
switched host defs to be based on a collection
added option to disable the health check by using a 0 value for the timeout
fixing incorrect host list creation name
added misc server settings option
changing systemd to use the env file for it to be more robust
fixed log dir assignment to work from the ansible var
extracted log levels to role vars
