### PR TITLE
Fix key imports signature verification

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,9 @@ kafka_url: "{{ kafka_mirror }}/{{ kafka_version }}/kafka_{{ kafka_scala_version 
 kafka_bin_tmp: "/tmp/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tar.gz"
 
 kafka_sig_url: "https://dist.apache.org/repos/dist/release/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz.asc"
+kafka_keys_url: "https://dist.apache.org/repos/dist/release/kafka/KEYS"
+kafka_keys_tmp: "/tmp/kafka_KEYS"
 kafka_sig_tmp: "/tmp/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tar.gz.asc"
-kafka_sig_id: E0A61EEA
-# NB: ^ this is the trusted signer's signature id.
 
 kafka_conf_dir: /etc/kafka
 kafka_data_dir: /var/kafka

--- a/tasks/kafka-install.yml
+++ b/tasks/kafka-install.yml
@@ -9,24 +9,18 @@
   tags:
     - kafka-install
 
+- name: "Download the kafka PGP keys"
+  get_url: url={{ kafka_keys_url }} dest={{ kafka_keys_tmp }} timeout=600
+  tags:
+    - kafka-install
+
+- name: "Import kafka PGP keys"
+  shell: gpg --import {{ kafka_keys_tmp }}
+  tags:
+    - kafka-install
+
 - name: "Verify kafka binary package archive authenticity"
   shell: gpg --verify {{ kafka_sig_tmp }} {{ kafka_bin_tmp }}
-  ignore_errors: yes
-  register: verify
-  changed_when: False
-  tags:
-    - kafka-install
-
-- name: "Import PGP keys and retry verifying authenticity"
-  shell: gpg --keyserver pgp.mit.edu --recv-key {{ kafka_sig_id }} || gpg --keyserver pgp.surfnet.nl --recv-key {{ kafka_sig_id }}
-  when: verify.rc != 0
-  tags:
-    - kafka-install
-
-- name: "Retry kafka binary package archive autenticity verification"
-  shell: gpg --verify {{ kafka_sig_tmp }} {{ kafka_bin_tmp }}
-  when: verify.rc != 0
-  changed_when: False
   tags:
     - kafka-install
 


### PR DESCRIPTION
Verified that signature verification with the default version (0.9.0.1) and with 0.10.1.0, which did not work previously.


fixes #11 