### PR TITLE
flag to disable the builtin java/JDK deployment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ kafka_version: "0.9.0.1"
 kafka_scala_version: "2.11"
 # NB: 2.11 is recommended at https://kafka.apache.org/downloads.html.
 
+kafka_java_enabled: true
+# set false if the role should not handle the java dependency
+
 kafka_mirror: http://apache.mirrors.tds.net/kafka
 kafka_url: "{{ kafka_mirror }}/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
 kafka_bin_tmp: "/tmp/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tar.gz"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - include: check-env.yml
 - include: java.yml
+  when: kafka_java_enabled
 - include: system.yml
 - include: limits.yml
 - include: kafka-install.yml


### PR DESCRIPTION
Best is to be able to completely disable the builtin deployment of java(jdk) which is hardcoded and pointing to old JDK7.
This also allows to run the role in check-mode for most parts.
Patch is 100% downward compatible ( as the new flag is enabled by default )

Other PR coming, that adds 2 more `check_mode: no`, so the role can be completely `--check` tested 👍 

happy to get this merged @jaytaylor , thx in advance !
