### PR TITLE
Feature/fix travis

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,7 +65,7 @@ server:
   num_io_threads: 8
   background_threads:
   queued_max_requests:
-  host_name:
+  host_name: localhost
   advertised_host_name:
   advertised_port:
   advertised_listeners:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ kafka_heap_opts: "-Xmx1G -Xms1G"
 
 nofiles_limit: 50000
 
-kafka_port_test_timeout_seconds: 30
+kafka_port_test_timeout_seconds: 120
 
 kafka_generate_broker_id: yes
 

--- a/tasks/kafka-install.yml
+++ b/tasks/kafka-install.yml
@@ -7,9 +7,11 @@
 
 - name: "Download the kafka PGP keys"
   get_url: url={{ kafka_keys_url }} dest={{ kafka_keys_tmp }} timeout=600
+  changed_when: False
 
 - name: "Import kafka PGP keys"
   shell: gpg --import {{ kafka_keys_tmp }}
+  changed_when: False
 
 - name: "Verify kafka binary package archive authenticity"
   shell: gpg --verify {{ kafka_sig_tmp }} {{ kafka_bin_tmp }}

--- a/tasks/kafka-install.yml
+++ b/tasks/kafka-install.yml
@@ -15,6 +15,7 @@
 
 - name: "Verify kafka binary package archive authenticity"
   shell: gpg --verify {{ kafka_sig_tmp }} {{ kafka_bin_tmp }}
+  changed_when: False
 
 - name: "Extract downloaded kafka archive"
   unarchive: copy=no creates=/usr/local/kafka_{{ kafka_scala_version }}-{{ kafka_version }} dest=/usr/local src={{ kafka_bin_tmp }}


### PR DESCRIPTION
Hi,

I tried to debug the travis-ci issue. On of the problems was with idempotency checks because gpg tests were considered state-changing.  The timeout was too small on some builds so I increased it (we can probably safely reduce it slightly). 

Now there is a problem with ansible >= 2.0
I tested every pip-installable version between 2.0.0.2 and 2.3.0.0 and  they all fail at the `wait_for` task. 
However I have found that kafka was correctly listening  on the required port (see my debug branch https://github.com/asaladin/ansible-kafka/tree/feature/debug-travis and the travis build https://travis-ci.org/asaladin/ansible-kafka/jobs/230334549#L547, indicating that `wait_for` fails but netstat shows that  the jvm is listening). 

My guess it it may be an Ansible bug. I first thought it was due to ansible running with "--connection=local" but I could not reproduce that issue in another repository using netcat as a server. 