### PR TITLE
Fixing typo with advertised.listeners (. was a _)

### DIFF
--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -70,7 +70,7 @@ listeners={{ server.listeners }}
 {% if server.advertised_listeners %}
 # default: null
 # Listeners to publish to ZooKeeper for clients to use, if different than the listeners above. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used.
-advertised_listeners={{ server.advertised_listeners }}
+advertised.listeners={{ server.advertised_listeners }}
 {% endif %}
 
 {% if server.host_name %}


### PR DESCRIPTION
I needed to use advertised.listeners and noticed it didn't work because of the typo. I am able to use "misc" as a workaround for now, good idea