### PR TITLE
update kafka version to 0.11/1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ python: 2.7
 
 env:
   matrix:
-  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS="kafka_version=0.8.2.2"
-  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS="kafka_version=0.9.0.0"
-  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=0.8.2.2"
-  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=0.9.0.0"
-  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=0.9.0.0 kafka_generate_broker_id=false"
+  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
+  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS="kafka_version=1.0.0"
+  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
+  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=1.0.0"
+  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS="kafka_version=1.0.0 kafka_generate_broker_id=false"
 
 before_install:
 - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 An ansible role to install and configure [kafka](https://kafka.apache.org/) distributed pub/sub messaging queue clusters.
 
-Note: Build is currently failing due to issues with Kafka 2.0.  Rest assured that it works fine, but I haven't had time to chase this one down.  PR's gladly accepted :)
 
 ## How to get it
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ kafka_zookeeper_port: 2181
 kafka_hosts: # <-- must be overridden further up the chain
 # e.g. [ 'srvr1', 'srvr2' ]
 
-kafka_version: "0.9.0.1"
+kafka_version: "0.11.0.2"
 
 kafka_scala_version: "2.11"
 # NB: 2.11 is recommended at https://kafka.apache.org/downloads.html.

--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -4,6 +4,7 @@
   shell: ( test -r /etc/fstab && find /dev/disk/by-uuid/ -type l -printf "%f\n" | sort | head -1 | grep --ignore-case --only-matching --extended-regexp --max 1 '[0-9a-f]{3,}[0-9a-f-]+' | tr -d '-' || echo '0' ; ifconfig | grep --ignore-case --only-matching --extended-regexp '([0-9a-f]{2}:){5}[0-9a-f]{2}' | tr -d ':' | tr -d '\n') | python -c 'import sys; x, y = sys.stdin.read().split(chr(10))[0:2]; x = int(x, 16); y = int(y, 16); sys.stdout.write((str(x + y)[-9:])); sys.exit(1 if x == 0 and y == 0 else 0)'
   register: machineidinteger
   changed_when: False
+  when: kafka_generate_broker_id | bool
 
 - name: "Use generated unique machine id integer as broker id"
   set_fact: kafka_broker_id={{ machineidinteger.stdout_lines[0] }}


### PR DESCRIPTION
Hi,

I noticed the travis build was failing due to 404 error on kafka archive. I updated kafka versions to 0.11 and 1.0. 
I also added a check to only generate a broker id when kafka_generate_broker_id is set to true. Indeed there are cases where /dev/disk/by-uuid/ might not be accessible (lxc containers for example).

