### PR TITLE
kafka_server role variable not being merged correctly with kafka_server_defaults

### DIFF
--- a/tasks/kafka-cfg.yml
+++ b/tasks/kafka-cfg.yml
@@ -1,9 +1,9 @@
 ---
-- name: "Generate kafka_server fact"
-  set_fact: kafka_server="{{ kafka_server_defaults | combine(kafka_server) }}"
+- name: "Generate kafka_server_config fact"
+  set_fact: kafka_server_config="{{ kafka_server_defaults | combine(kafka_server) }}"
 
 - name: "Generate kafka_healtcheck_address fact"
-  set_fact: kafka_healthcheck_address="{{ ((kafka_server.host_name | default('127.0.0.1')) == '') | ternary('127.0.0.1', kafka_server.host_name) }}"
+  set_fact: kafka_healthcheck_address="{{ ((kafka_server_config.host_name | default('127.0.0.1')) == '') | ternary('127.0.0.1', kafka_server_config.host_name) }}"
   when: kafka_healthcheck_address == ""
 
 - name: "Generate kafka_producer fact"
@@ -29,7 +29,7 @@
   set_fact: kafka_zookeeper_connection_string="{{ kafka_zookeeper_hosts | join(':' ~ kafka_zookeeper_port ~ ',') }}:{{ kafka_zookeeper_port }}"
 
 - name: "Generate the kafka hosts connection string"
-  set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ kafka_server.port ~ ',') }}:{{ kafka_server.port }}"
+  set_fact: kafka_connection_string="{{ kafka_hosts | join(':' ~ kafka_server_config.port ~ ',') }}:{{ kafka_server_config.port }}"
 
 - name: "Render and write out kafka configuration files"
   template: src=usr/local/kafka/config/{{ item }}.j2 dest="{{ kafka_conf_dir }}/{{ item }}" mode=0640 owner={{ kafka_user }} group={{ kafka_group }}
@@ -62,14 +62,14 @@
 - meta: flush_handlers
 
 - name: "Wait for kafka to come up and open it's server port"
-  wait_for: port={{ kafka_server.port }} host={{ kafka_healthcheck_address }} connect_timeout={{ kafka_port_test_timeout_seconds }} timeout={{ kafka_port_test_timeout_seconds }}
+  wait_for: port={{ kafka_server_config.port }} host={{ kafka_healthcheck_address }} connect_timeout={{ kafka_port_test_timeout_seconds }} timeout={{ kafka_port_test_timeout_seconds }}
   ignore_errors: yes
   register: healthcheck
   tags:
     - kafka-healthcheck
 
 - name: "Check kafka port test result"
-  fail: msg="Kafka port not open on host={{ kafka_healthcheck_address }}, port={{ kafka_server.port }}"
+  fail: msg="Kafka port not open on host={{ kafka_healthcheck_address }}, port={{ kafka_server_config.port }}"
   when: healthcheck.elapsed is defined and (healthcheck.elapsed >= kafka_port_test_timeout_seconds and kafka_port_test_timeout_seconds > 0)
   tags:
     - kafka-healthcheck

--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -16,507 +16,507 @@ reserved.broker.max.id={{ kafka_reserved_broker_max_id }}
 # Specifies the ZooKeeper connection string in the form hostname:port, where hostname and port are the host and port for a node in your ZooKeeper cluster. To allow connecting through other ZooKeeper nodes when that host is down you can also specify multiple hosts in the form hostname1:port1,hostname2:port2,hostname3:port3.  ZooKeeper also allows you to add a "chroot" path which will make all kafka data for this cluster appear under a particular path. This is a way to setup multiple Kafka clusters or other applications on the same ZooKeeper cluster. To do this give a connection string in the form hostname1:port1,hostname2:port2,hostname3:port3/chroot/path which would put all this cluster's data under the path /chroot/path. Note that you must create this path yourself prior to starting the broker and consumers must use the same connection string.
 zookeeper.connect={{ kafka_zookeeper_connection_string }}
 
-{% if kafka_server %}
+{% if kafka_server_config %}
 
-{% if kafka_server.log_dirs %}
+{% if kafka_server_config.log_dirs %}
 # default: /tmp/kafka-logs
 # A comma-separated list of one or more directories in which Kafka data is stored. Each new partition that is created will be placed in the directory which currently has the fewest partitions.
-log.dirs={{ kafka_server.log_dirs }}
+log.dirs={{ kafka_server_config.log_dirs }}
 {% endif %}
 
-{% if kafka_server.port %}
+{% if kafka_server_config.port %}
 # default: 9092
 # The port on which the server accepts client connections.
 #
 # Kafka 0.10.0
 # DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. the port to listen and accept connections on
-port={{ kafka_server.port }}
+port={{ kafka_server_config.port }}
 {% endif %}
 
-{% if kafka_server.message_max_bytes %}
+{% if kafka_server_config.message_max_bytes %}
 # default: 1000000
 # The maximum size of a message that the server can receive. It is important that this property be in sync with the maximum fetch size your consumers use or else an unruly producer will be able to publish messages too large for consumers to consume.
-message.max.bytes={{ kafka_server.message_max_bytes }}
+message.max.bytes={{ kafka_server_config.message_max_bytes }}
 {% endif %}
 
-{% if kafka_server.num_network_threads %}
+{% if kafka_server_config.num_network_threads %}
 # The number of network threads that the server uses for handling network requests. You probably don't need to change this.
-num.network.threads={{ kafka_server.num_network_threads }}
+num.network.threads={{ kafka_server_config.num_network_threads }}
 {% endif %}
 
-{% if kafka_server.num_io_threads %}
+{% if kafka_server_config.num_io_threads %}
 # The number of I/O threads that the server uses for executing requests. You should have at least as many threads as you have disks.
-num.io.threads={{ kafka_server.num_io_threads }}
+num.io.threads={{ kafka_server_config.num_io_threads }}
 {% endif %}
 
-{% if kafka_server.background_threads %}
+{% if kafka_server_config.background_threads %}
 # default: 10
 # The number of threads to use for various background processing tasks such as file deletion. You should not need to change this.
-background.threads={{ kafka_server.background_threads }}
+background.threads={{ kafka_server_config.background_threads }}
 {% endif %}
 
-{% if kafka_server.queued_max_requests %}
+{% if kafka_server_config.queued_max_requests %}
 # default: 500
 # The number of requests that can be queued up for processing by the I/O threads before the network threads stop reading in new requests.
-queued.max.requests={{ kafka_server.queued_max_requests }}
+queued.max.requests={{ kafka_server_config.queued_max_requests }}
 {% endif %}
 
-{% if kafka_server.listeners %}
+{% if kafka_server_config.listeners %}
 # default: null
 # Listener List - Comma-separated list of URIs we will listen on and their protocols. Specify hostname as 0.0.0.0 to bind to all interfaces. Leave hostname empty to bind to default interface. Examples of legal listener lists: PLAINTEXT://myhost:9092,TRACE://:9091 PLAINTEXT://0.0.0.0:9092, TRACE://localhost:9093
-listeners={{ kafka_server.listeners }}
+listeners={{ kafka_server_config.listeners }}
 {% endif %}
 
-{% if kafka_server.advertised_listeners %}
+{% if kafka_server_config.advertised_listeners %}
 # default: null
 # Listeners to publish to ZooKeeper for clients to use, if different than the listeners above. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, the value for `listeners` will be used.
-advertised.listeners={{ kafka_server.advertised_listeners }}
+advertised.listeners={{ kafka_server_config.advertised_listeners }}
 {% endif %}
 
-{% if kafka_server.host_name %}
+{% if kafka_server_config.host_name %}
 # default: null
 # Hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces, and publish one to ZK.
 #
 # Kafka 0.10.0
 # DEPRECATED: only used when `listeners` is not set. Use `listeners` instead. hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces
-host.name={{ kafka_server.host_name }}
+host.name={{ kafka_server_config.host_name }}
 {% endif %}
 
-{% if kafka_server.advertised_host_name %}
+{% if kafka_server_config.advertised_host_name %}
 # default: null
 # If this is set this is the hostname that will be given out to producers, consumers, and other brokers to connect to.
 #
 # Kafka 0.10.0
 # DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the interface to which the broker binds. If this is not set, it will use the value for `host.name` if configured. Otherwise it will use the value returned from java.net.InetAddress.getCanonicalHostName().
-advertised.host.name={{ kafka_server.advertised_host_name }}
+advertised.host.name={{ kafka_server_config.advertised_host_name }}
 {% endif %}
 
-{% if kafka_server.advertised_port %}
+{% if kafka_server_config.advertised_port %}
 # default: null
 # The port to give out to producers, consumers, and other brokers to use in establishing connections. This only needs to be set if this port is different from the port the server should bind to.
 #
 # Kafka 0.10.0
 # DEPRECATED: only used when `advertised.listeners` or `listeners` are not set. Use `advertised.listeners` instead. The port to publish to ZooKeeper for clients to use. In IaaS environments, this may need to be different from the port to which the broker binds. If this is not set, it will publish the same port that the broker binds to.
-advertised.port={{ kafka_server.advertised_port }}
+advertised.port={{ kafka_server_config.advertised_port }}
 {% endif %}
 
-{% if kafka_server.socket_send_buffer_bytes %}
+{% if kafka_server_config.socket_send_buffer_bytes %}
 # default: 100 * 1024
 # The SO_SNDBUFF buffer the server prefers for socket connections.
-socket.send.buffer.bytes={{ kafka_server.socket_send_buffer_bytes }}
+socket.send.buffer.bytes={{ kafka_server_config.socket_send_buffer_bytes }}
 {% endif %}
 
-{% if kafka_server.socket_receive_buffer_bytes %}
+{% if kafka_server_config.socket_receive_buffer_bytes %}
 # default: 100 * 1024
 # The SO_RCVBUFF buffer the server prefers for socket connections.
-socket.receive.buffer.bytes={{ kafka_server.socket_receive_buffer_bytes }}
+socket.receive.buffer.bytes={{ kafka_server_config.socket_receive_buffer_bytes }}
 {% endif %}
 
-{% if kafka_server.socket_request_max_bytes %}
+{% if kafka_server_config.socket_request_max_bytes %}
 # default: 100 * 1024 * 1024
 # The maximum request size the server will allow. This prevents the server from running out of memory and should be smaller than the Java heap size.
-socket.request.max.bytes={{ kafka_server.socket_request_max_bytes }}
+socket.request.max.bytes={{ kafka_server_config.socket_request_max_bytes }}
 {% endif %}
 
-{% if kafka_server.num_partitions %}
+{% if kafka_server_config.num_partitions %}
 # The default number of partitions per topic if a partition count isn't given at topic creation time.
-num.partitions={{ kafka_server.num_partitions }}
+num.partitions={{ kafka_server_config.num_partitions }}
 {% endif %}
 
-{% if kafka_server.log_segment_bytes %}
+{% if kafka_server_config.log_segment_bytes %}
 # default: 1024 * 1024 * 1024
 # The log for a topic partition is stored as a directory of segment files. This setting controls the size to which a segment file will grow before a new segment is rolled over in the log. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.segment.bytes={{ kafka_server.log_segment_bytes }}
+log.segment.bytes={{ kafka_server_config.log_segment_bytes }}
 {% endif %}
 
-{% if kafka_server.log_roll_ms %}
+{% if kafka_server_config.log_roll_ms %}
 # default: 24 * 7 hours
 # This setting will force Kafka to roll a new log segment even if the log.segment.bytes size has not been reached. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.roll.ms={{ kafka_server.log_roll_ms }}
+log.roll.ms={{ kafka_server_config.log_roll_ms }}
 {% endif %}
 
-{% if kafka_server.log_roll_hours %}
+{% if kafka_server_config.log_roll_hours %}
 # default: 24 * 7 hours
 # This setting will force Kafka to roll a new log segment even if the log.segment.bytes size has not been reached. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.roll.hours={{ kafka_server.log_roll_hours }}
+log.roll.hours={{ kafka_server_config.log_roll_hours }}
 {% endif %}
 
-{% if kafka_server.log_cleanup_policy %}
+{% if kafka_server_config.log_cleanup_policy %}
 # default: delete
 # This can take either the value delete or compact. If delete is set, log segments will be deleted when they reach the size or time limits set. If compact is set log compaction will be used to clean out obsolete records. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.cleanup.policy={{ kafka_server.log_cleanup_policy }}
+log.cleanup.policy={{ kafka_server_config.log_cleanup_policy }}
 {% endif %}
 
-{% if kafka_server.log_retention_ms %}
+{% if kafka_server_config.log_retention_ms %}
 # default: 7 days
 # The amount of time to keep a log segment before it is deleted, i.e. the default data retention window for all topics. Note that if both log.retention.minutes and log.retention.bytes are both set we delete a segment when either limit is exceeded. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.retention.ms={{ kafka_server.log_retention_ms }}
+log.retention.ms={{ kafka_server_config.log_retention_ms }}
 {% endif %}
 
-{% if kafka_server.log_retention_minutes %}
+{% if kafka_server_config.log_retention_minutes %}
 # default: 7 days
 # The amount of time to keep a log segment before it is deleted, i.e. the default data retention window for all topics. Note that if both log.retention.minutes and log.retention.bytes are both set we delete a segment when either limit is exceeded. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.retention.minutes={{ kafka_server.log_retention_minutes }}
+log.retention.minutes={{ kafka_server_config.log_retention_minutes }}
 {% endif %}
 
-{% if kafka_server.log_retention_hours %}
+{% if kafka_server_config.log_retention_hours %}
 # default: 7 days
 # The amount of time to keep a log segment before it is deleted, i.e. the default data retention window for all topics. Note that if both log.retention.minutes and log.retention.bytes are both set we delete a segment when either limit is exceeded. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.retention.hours={{ kafka_server.log_retention_hours }}
+log.retention.hours={{ kafka_server_config.log_retention_hours }}
 {% endif %}
 
-{% if kafka_server.log_retention_bytes %}
+{% if kafka_server_config.log_retention_bytes %}
 # default: -1
 # The amount of data to retain in the log for each topic-partitions. Note that this is the limit per-partition so multiply by the number of partitions to get the total data retained for the topic. Also note that if both log.retention.hours and log.retention.bytes are both set we delete a segment when either limit is exceeded. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.retention.bytes={{ kafka_server.log_retention_bytes }}
+log.retention.bytes={{ kafka_server_config.log_retention_bytes }}
 {% endif %}
 
-{% if kafka_server.log_retention_check_interval_ms %}
+{% if kafka_server_config.log_retention_check_interval_ms %}
 # default: 5 minutes
 # The period with which we check whether any log segment is eligible for deletion to meet the retention policies.
-log.retention.check.interval.ms={{ kafka_server.log_retention_check_interval_ms }}
+log.retention.check.interval.ms={{ kafka_server_config.log_retention_check_interval_ms }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_enable %}
+{% if kafka_server_config.log_cleaner_enable %}
 # default: false
 # This configuration must be set to true for log compaction to run.
-log.cleaner.enable={{ kafka_server.log_cleaner_enable }}
+log.cleaner.enable={{ kafka_server_config.log_cleaner_enable }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_threads %}
+{% if kafka_server_config.log_cleaner_threads %}
 # The number of threads to use for cleaning logs in log compaction.
-log.cleaner.threads={{ kafka_server.log_cleaner_threads }}
+log.cleaner.threads={{ kafka_server_config.log_cleaner_threads }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_io_max_bytes_per_second %}
+{% if kafka_server_config.log_cleaner_io_max_bytes_per_second %}
 # default: Double.MaxValue
 # The maximum amount of I/O the log cleaner can do while performing log compaction. This setting allows setting a limit for the cleaner to avoid impacting live request serving.
-log.cleaner.io.max.bytes.per.second={{ kafka_server.log_cleaner_io_max_bytes_per_second }}
+log.cleaner.io.max.bytes.per.second={{ kafka_server_config.log_cleaner_io_max_bytes_per_second }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_dedupe_buffer_size %}
+{% if kafka_server_config.log_cleaner_dedupe_buffer_size %}
 # default: 500*1024*1024
 # The size of the buffer the log cleaner uses for indexing and deduplicating logs during cleaning. Larger is better provided you have sufficient memory.
-log.cleaner.dedupe.buffer.size={{ kafka_server.log_cleaner_dedupe_buffer_size }}
+log.cleaner.dedupe.buffer.size={{ kafka_server_config.log_cleaner_dedupe_buffer_size }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_io_buffer_size %}
+{% if kafka_server_config.log_cleaner_io_buffer_size %}
 # default: 512*1024
 # The size of the I/O chunk used during log cleaning. You probably don't need to change this.
-log.cleaner.io.buffer.size={{ kafka_server.log_cleaner_io_buffer_size }}
+log.cleaner.io.buffer.size={{ kafka_server_config.log_cleaner_io_buffer_size }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_io_buffer_load_factor %}
+{% if kafka_server_config.log_cleaner_io_buffer_load_factor %}
 # default: 0.9
 # The load factor of the hash table used in log cleaning. You probably don't need to change this.
-log.cleaner.io.buffer.load.factor={{ kafka_server.log_cleaner_io_buffer_load_factor }}
+log.cleaner.io.buffer.load.factor={{ kafka_server_config.log_cleaner_io_buffer_load_factor }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_backoff_ms %}
+{% if kafka_server_config.log_cleaner_backoff_ms %}
 # default: 15000
 # The interval between checks to see if any logs need cleaning.
-log.cleaner.backoff.ms={{ kafka_server.log_cleaner_backoff_ms }}
+log.cleaner.backoff.ms={{ kafka_server_config.log_cleaner_backoff_ms }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_min_cleanable_ratio %}
+{% if kafka_server_config.log_cleaner_min_cleanable_ratio %}
 # default: 0.5
 # This configuration controls how frequently the log compactor will attempt to clean the log (assuming log compaction is enabled). By default we will avoid cleaning a log where more than 50% of the log has been compacted. This ratio bounds the maximum space wasted in the log by duplicates (at 50% at most 50% of the log could be duplicates). A higher ratio will mean fewer, more efficient cleanings but will mean more wasted space in the log. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.cleaner.min.cleanable.ratio={{ kafka_server.log_cleaner_min_cleanable_ratio }}
+log.cleaner.min.cleanable.ratio={{ kafka_server_config.log_cleaner_min_cleanable_ratio }}
 {% endif %}
 
-{% if kafka_server.log_cleaner_delete_retention_ms %}
+{% if kafka_server_config.log_cleaner_delete_retention_ms %}
 # default: 1 day
 # The amount of time to retain delete tombstone markers for log compacted topics. This setting also gives a bound on the time in which a consumer must complete a read if they begin from offset 0 to ensure that they get a valid snapshot of the final stage (otherwise delete tombstones may be collected before they complete their scan). This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.cleaner.delete.retention.ms={{ kafka_server.log_cleaner_delete_retention_ms }}
+log.cleaner.delete.retention.ms={{ kafka_server_config.log_cleaner_delete_retention_ms }}
 {% endif %}
 
-{% if kafka_server.log_index_size_max_bytes %}
+{% if kafka_server_config.log_index_size_max_bytes %}
 # default: 10 * 1024 * 1024
 # The maximum size in bytes we allow for the offset index for each log segment. Note that we will always pre-allocate a sparse file with this much space and shrink it down when the log rolls. If the index fills up we will roll a new log segment even if we haven't reached the log.segment.bytes limit. This setting can be overridden on a per-topic basis (see the per-topic configuration section).
-log.index.size.max.bytes={{ kafka_server.log_index_size_max_bytes }}
+log.index.size.max.bytes={{ kafka_server_config.log_index_size_max_bytes }}
 {% endif %}
 
-{% if kafka_server.log_index_interval_bytes %}
+{% if kafka_server_config.log_index_interval_bytes %}
 # default: 4096
 # The byte interval at which we add an entry to the offset index. When executing a fetch request the server must do a linear scan for up to this many bytes to find the correct position in the log to begin and end the fetch. So setting this value to be larger will mean larger index files (and a bit more memory usage) but less scanning. However the server will never add more than one index entry per log append (even if more than log.index.interval worth of messages are appended). In general you probably don't need to mess with this value.
-log.index.interval.bytes={{ kafka_server.log_index_interval_bytes }}
+log.index.interval.bytes={{ kafka_server_config.log_index_interval_bytes }}
 {% endif %}
 
-{% if kafka_server.log_flush_interval_messages %}
+{% if kafka_server_config.log_flush_interval_messages %}
 # default: Long.MaxValue
 # The number of messages written to a log partition before we force an fsync on the log. Setting this lower will sync data to disk more often but will have a major impact on performance. We generally recommend that people make use of replication for durability rather than depending on single-server fsync, however this setting can be used to be extra certain.
-log.flush.interval.messages={{ kafka_server.log_flush_interval_messages }}
+log.flush.interval.messages={{ kafka_server_config.log_flush_interval_messages }}
 {% endif %}
 
-{% if kafka_server.log_flush_scheduler_interval_ms %}
+{% if kafka_server_config.log_flush_scheduler_interval_ms %}
 # default: Long.MaxValue
 # The frequency in ms that the log flusher checks whether any log is eligible to be flushed to disk.
-log.flush.scheduler.interval.ms={{ kafka_server.log_flush_scheduler_interval_ms }}
+log.flush.scheduler.interval.ms={{ kafka_server_config.log_flush_scheduler_interval_ms }}
 {% endif %}
 
-{% if kafka_server.log_flush_interval_ms %}
+{% if kafka_server_config.log_flush_interval_ms %}
 # default: Long.MaxValue
 # The maximum time between fsync calls on the log. If used in conjuction with log.flush.interval.messages the log will be flushed when either criteria is met.
-log.flush.interval.ms={{ kafka_server.log_flush_interval_ms }}
+log.flush.interval.ms={{ kafka_server_config.log_flush_interval_ms }}
 {% endif %}
 
-{% if kafka_server.log_delete_delay_ms %}
+{% if kafka_server_config.log_delete_delay_ms %}
 # default: 60000
 # The period of time we hold log files around after they are removed from the in-memory segment index. This period of time allows any in-progress reads to complete uninterrupted without locking. You generally don't need to change this.
-log.delete.delay.ms={{ kafka_server.log_delete_delay_ms }}
+log.delete.delay.ms={{ kafka_server_config.log_delete_delay_ms }}
 {% endif %}
 
-{% if kafka_server.log_flush_offset_checkpoint_interval_ms %}
+{% if kafka_server_config.log_flush_offset_checkpoint_interval_ms %}
 # default: 60000
 # The frequency with which we checkpoint the last flush point for logs for recovery. You should not need to change this.
-log.flush.offset.checkpoint.interval.ms={{ kafka_server.log_flush_offset_checkpoint_interval_ms }}
+log.flush.offset.checkpoint.interval.ms={{ kafka_server_config.log_flush_offset_checkpoint_interval_ms }}
 {% endif %}
 
-{% if kafka_server.log_segment_delete_delay_ms %}
+{% if kafka_server_config.log_segment_delete_delay_ms %}
 # default: 60000
 # the amount of time to wait before deleting a file from the filesystem.
-log.segment.delete.delay.ms={{ kafka_server.log_segment_delete_delay_ms }}
+log.segment.delete.delay.ms={{ kafka_server_config.log_segment_delete_delay_ms }}
 {% endif %}
 
-{% if kafka_server.auto_create_topics_enable %}
+{% if kafka_server_config.auto_create_topics_enable %}
 # default: true
 # Enable auto creation of topic on the server. If this is set to true then attempts to produce data or fetch metadata for a non-existent topic will automatically create it with the default replication factor and number of partitions.
-auto.create.topics.enable={{ kafka_server.auto_create_topics_enable }}
+auto.create.topics.enable={{ kafka_server_config.auto_create_topics_enable }}
 {% endif %}
 
-{% if kafka_server.controller_socket_timeout_ms %}
+{% if kafka_server_config.controller_socket_timeout_ms %}
 # default: 30000
 # The socket timeout for commands from the partition management controller to the replicas.
-controller.socket.timeout.ms={{ kafka_server.controller_socket_timeout_ms }}
+controller.socket.timeout.ms={{ kafka_server_config.controller_socket_timeout_ms }}
 {% endif %}
 
-{% if kafka_server.controller_message_queue_size %}
+{% if kafka_server_config.controller_message_queue_size %}
 # default: Int.MaxValue
 # The buffer size for controller-to-broker-channels
-controller.message.queue.size={{ kafka_server.controller_message_queue_size }}
+controller.message.queue.size={{ kafka_server_config.controller_message_queue_size }}
 {% endif %}
 
-{% if kafka_server.default_replication_factor %}
+{% if kafka_server_config.default_replication_factor %}
 # The default replication factor for automatically created topics.
-default.replication.factor={{ kafka_server.default_replication_factor }}
+default.replication.factor={{ kafka_server_config.default_replication_factor }}
 {% endif %}
 
-{% if kafka_server.replica_lag_time_max_ms %}
+{% if kafka_server_config.replica_lag_time_max_ms %}
 # default: 10000
 # If a follower hasn't sent any fetch requests for this window of time, the leader will remove the follower from ISR (in-sync replicas) and treat it as dead.
-replica.lag.time.max.ms={{ kafka_server.replica_lag_time_max_ms }}
+replica.lag.time.max.ms={{ kafka_server_config.replica_lag_time_max_ms }}
 {% endif %}
 
-{% if kafka_server.replica_lag_max_messages %}
+{% if kafka_server_config.replica_lag_max_messages %}
 # default: 4000
 # If a replica falls more than this many messages behind the leader, the leader will remove the follower from ISR and treat it as dead.
-replica.lag.max.messages={{ kafka_server.replica_lag_max_messages }}
+replica.lag.max.messages={{ kafka_server_config.replica_lag_max_messages }}
 {% endif %}
 
-{% if kafka_server.replica_socket_timeout_ms %}
+{% if kafka_server_config.replica_socket_timeout_ms %}
 # default: 30 * 1000
 # The socket timeout for network requests to the leader for replicating data.
-replica.socket.timeout.ms={{ kafka_server.replica_socket_timeout_ms }}
+replica.socket.timeout.ms={{ kafka_server_config.replica_socket_timeout_ms }}
 {% endif %}
 
-{% if kafka_server.replica_socket_receive_buffer_bytes %}
+{% if kafka_server_config.replica_socket_receive_buffer_bytes %}
 # default: 64 * 1024
 # The socket receive buffer for network requests to the leader for replicating data.
-replica.socket.receive.buffer.bytes={{ kafka_server.replica_socket_receive_buffer_bytes }}
+replica.socket.receive.buffer.bytes={{ kafka_server_config.replica_socket_receive_buffer_bytes }}
 {% endif %}
 
-{% if kafka_server.replica_fetch_max_bytes %}
+{% if kafka_server_config.replica_fetch_max_bytes %}
 # default: 1024 * 1024
 # The number of byes of messages to attempt to fetch for each partition in the fetch requests the replicas send to the leader.
-replica.fetch.max.bytes={{ kafka_server.replica_fetch_max_bytes }}
+replica.fetch.max.bytes={{ kafka_server_config.replica_fetch_max_bytes }}
 {% endif %}
 
-{% if kafka_server.replica_fetch_wait_max_ms %}
+{% if kafka_server_config.replica_fetch_wait_max_ms %}
 # default: 500
 # The maximum amount of time to wait time for data to arrive on the leader in the fetch requests sent by the replicas to the leader.
-replica.fetch.wait.max.ms={{ kafka_server.replica_fetch_wait_max_ms }}
+replica.fetch.wait.max.ms={{ kafka_server_config.replica_fetch_wait_max_ms }}
 {% endif %}
 
-{% if kafka_server.replica_fetch_min_bytes %}
+{% if kafka_server_config.replica_fetch_min_bytes %}
 # Minimum bytes expected for each fetch response for the fetch requests from the replica to the leader. If not enough bytes, wait up to replica.fetch.wait.max.ms for this many bytes to arrive.
-replica.fetch.min.bytes={{ kafka_server.replica_fetch_min_bytes }}
+replica.fetch.min.bytes={{ kafka_server_config.replica_fetch_min_bytes }}
 {% endif %}
 
-{% if kafka_server.num_replica_fetchers %}
+{% if kafka_server_config.num_replica_fetchers %}
 # Number of threads used to replicate messages from leaders. Increasing this value can increase the degree of I/O parallelism in the follower broker.
-num.replica.fetchers={{ kafka_server.num_replica_fetchers }}
+num.replica.fetchers={{ kafka_server_config.num_replica_fetchers }}
 {% endif %}
 
-{% if kafka_server.replica_high_watermark_checkpoint_interval_ms %}
+{% if kafka_server_config.replica_high_watermark_checkpoint_interval_ms %}
 # default: 5000
 # The frequency with which each replica saves its high watermark to disk to handle recovery.
-replica.high.watermark.checkpoint.interval.ms={{ kafka_server.replica_high_watermark_checkpoint_interval_ms }}
+replica.high.watermark.checkpoint.interval.ms={{ kafka_server_config.replica_high_watermark_checkpoint_interval_ms }}
 {% endif %}
 
-{% if kafka_server.fetch_purgatory_purge_interval_requests %}
+{% if kafka_server_config.fetch_purgatory_purge_interval_requests %}
 # default: 1000
 # The purge interval (in number of requests) of the fetch request purgatory.
-fetch.purgatory.purge.interval.requests={{ kafka_server.fetch_purgatory_purge_interval_requests }}
+fetch.purgatory.purge.interval.requests={{ kafka_server_config.fetch_purgatory_purge_interval_requests }}
 {% endif %}
 
-{% if kafka_server.producer_purgatory_purge_interval_requests %}
+{% if kafka_server_config.producer_purgatory_purge_interval_requests %}
 # default: 1000
 # The purge interval (in number of requests) of the producer request purgatory.
-producer.purgatory.purge.interval.requests={{ kafka_server.producer_purgatory_purge_interval_requests }}
+producer.purgatory.purge.interval.requests={{ kafka_server_config.producer_purgatory_purge_interval_requests }}
 {% endif %}
 
-{% if kafka_server.zookeeper_session_timeout_ms %}
+{% if kafka_server_config.zookeeper_session_timeout_ms %}
 # default: 6000
 # ZooKeeper session timeout. If the server fails to heartbeat to ZooKeeper within this period of time it is considered dead. If you set this too low the server may be falsely considered dead; if you set it too high it may take too long to recognize a truly dead server.
-zookeeper.session.timeout.ms={{ kafka_server.zookeeper_session_timeout_ms }}
+zookeeper.session.timeout.ms={{ kafka_server_config.zookeeper_session_timeout_ms }}
 {% endif %}
 
-{% if kafka_server.zookeeper_connection_timeout_ms %}
+{% if kafka_server_config.zookeeper_connection_timeout_ms %}
 # default: 6000
 # The maximum amount of time that the client waits to establish a connection to zookeeper.
-zookeeper.connection.timeout.ms={{ kafka_server.zookeeper_connection_timeout_ms }}
+zookeeper.connection.timeout.ms={{ kafka_server_config.zookeeper_connection_timeout_ms }}
 {% endif %}
 
-{% if kafka_server.zookeeper_sync_time_ms %}
+{% if kafka_server_config.zookeeper_sync_time_ms %}
 # default: 2000
 # How far a ZK follower can be behind a ZK leader.
-zookeeper.sync.time.ms={{ kafka_server.zookeeper_sync_time_ms }}
+zookeeper.sync.time.ms={{ kafka_server_config.zookeeper_sync_time_ms }}
 {% endif %}
 
-{% if kafka_server.controlled_shutdown_enable %}
+{% if kafka_server_config.controlled_shutdown_enable %}
 # default: true
 # Enable controlled shutdown of the broker. If enabled, the broker will move all leaders on it to some other brokers before shutting itself down. This reduces the unavailability window during shutdown.
-controlled.shutdown.enable={{ kafka_server.controlled_shutdown_enable }}
+controlled.shutdown.enable={{ kafka_server_config.controlled_shutdown_enable }}
 {% endif %}
 
-{% if kafka_server.controlled_shutdown_max_retries %}
+{% if kafka_server_config.controlled_shutdown_max_retries %}
 # Number of retries to complete the controlled shutdown successfully before executing an unclean shutdown.
-controlled.shutdown.max.retries={{ kafka_server.controlled_shutdown_max_retries }}
+controlled.shutdown.max.retries={{ kafka_server_config.controlled_shutdown_max_retries }}
 {% endif %}
 
-{% if kafka_server.controlled_shutdown_retry_backoff_ms %}
+{% if kafka_server_config.controlled_shutdown_retry_backoff_ms %}
 # default: 5000
 # Backoff time between shutdown retries.
-controlled.shutdown.retry.backoff.ms={{ kafka_server.controlled_shutdown_retry_backoff_ms }}
+controlled.shutdown.retry.backoff.ms={{ kafka_server_config.controlled_shutdown_retry_backoff_ms }}
 {% endif %}
 
-{% if kafka_server.auto_leader_rebalance_enable %}
+{% if kafka_server_config.auto_leader_rebalance_enable %}
 # default: true
 # If this is enabled the controller will automatically try to balance leadership for partitions among the brokers by periodically returning leadership to the "preferred" replica for each partition if it is available.
-auto.leader.rebalance.enable={{ kafka_server.auto_leader_rebalance_enable }}
+auto.leader.rebalance.enable={{ kafka_server_config.auto_leader_rebalance_enable }}
 {% endif %}
 
-{% if kafka_server.leader_imbalance_per_broker_percentage %}
+{% if kafka_server_config.leader_imbalance_per_broker_percentage %}
 # default: 10
 # The percentage of leader imbalance allowed per broker. The controller will rebalance leadership if this ratio goes above the configured value per broker.
-leader.imbalance.per.broker.percentage={{ kafka_server.leader_imbalance_per_broker_percentage }}
+leader.imbalance.per.broker.percentage={{ kafka_server_config.leader_imbalance_per_broker_percentage }}
 {% endif %}
 
-{% if kafka_server.leader_imbalance_check_interval_seconds %}
+{% if kafka_server_config.leader_imbalance_check_interval_seconds %}
 # default: 300
 # The frequency with which to check for leader imbalance.
-leader.imbalance.check.interval.seconds={{ kafka_server.leader_imbalance_check_interval_seconds }}
+leader.imbalance.check.interval.seconds={{ kafka_server_config.leader_imbalance_check_interval_seconds }}
 {% endif %}
 
-{% if kafka_server.offset_metadata_max_bytes %}
+{% if kafka_server_config.offset_metadata_max_bytes %}
 # default: 4096
 # The maximum amount of metadata to allow clients to save with their offsets.
-offset.metadata.max.bytes={{ kafka_server.offset_metadata_max_bytes }}
+offset.metadata.max.bytes={{ kafka_server_config.offset_metadata_max_bytes }}
 {% endif %}
 
-{% if kafka_server.max_connections_per_ip %}
+{% if kafka_server_config.max_connections_per_ip %}
 # default: Int.MaxValue
 # The maximum number of connections that a broker allows from each ip address.
-max.connections.per.ip={{ kafka_server.max_connections_per_ip }}
+max.connections.per.ip={{ kafka_server_config.max_connections_per_ip }}
 {% endif %}
 
-{% if kafka_server.max_connections_per_ip_overrides %}
+{% if kafka_server_config.max_connections_per_ip_overrides %}
 # Per-ip or hostname overrides to the default maximum number of connections.
-max.connections.per.ip.overrides={{ kafka_server.max_connections_per_ip_overrides }}
+max.connections.per.ip.overrides={{ kafka_server_config.max_connections_per_ip_overrides }}
 {% endif %}
 
-{% if kafka_server.connections_max_idle_ms %}
+{% if kafka_server_config.connections_max_idle_ms %}
 # default: 600000
 # Idle connections timeout: the server socket processor threads close the connections that idle more than this.
-connections.max.idle.ms={{ kafka_server.connections_max_idle_ms }}
+connections.max.idle.ms={{ kafka_server_config.connections_max_idle_ms }}
 {% endif %}
 
-{% if kafka_server.log_roll_jitter_ms %}
+{% if kafka_server_config.log_roll_jitter_ms %}
 # The maximum jitter to subtract from logRollTimeMillis.
-log.roll.jitter.ms={{ kafka_server.log_roll_jitter_ms }}
+log.roll.jitter.ms={{ kafka_server_config.log_roll_jitter_ms }}
 {% endif %}
 
-{% if kafka_server.log_roll_jitter_hours %}
+{% if kafka_server_config.log_roll_jitter_hours %}
 # The maximum jitter to subtract from logRollTimeMillis.
-log.roll.jitter.hours={{ kafka_server.log_roll_jitter_hours }}
+log.roll.jitter.hours={{ kafka_server_config.log_roll_jitter_hours }}
 {% endif %}
 
-{% if kafka_server.num_recovery_threads_per_data_dir %}
+{% if kafka_server_config.num_recovery_threads_per_data_dir %}
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
-num.recovery.threads.per.data.dir={{ kafka_server.num_recovery_threads_per_data_dir }}
+num.recovery.threads.per.data.dir={{ kafka_server_config.num_recovery_threads_per_data_dir }}
 {% endif %}
 
-{% if kafka_server.unclean_leader_election_enable %}
+{% if kafka_server_config.unclean_leader_election_enable %}
 # default: true
 # Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss.
-unclean.leader.election.enable={{ kafka_server.unclean_leader_election_enable }}
+unclean.leader.election.enable={{ kafka_server_config.unclean_leader_election_enable }}
 {% endif %}
 
-{% if kafka_server.delete_topic_enable %}
+{% if kafka_server_config.delete_topic_enable %}
 # default: false
 # Enable delete topic.
-delete.topic.enable={{ kafka_server.delete_topic_enable }}
+delete.topic.enable={{ kafka_server_config.delete_topic_enable }}
 {% endif %}
 
-{% if kafka_server.offsets_topic_num_partitions %}
+{% if kafka_server_config.offsets_topic_num_partitions %}
 # default: 50
 # The number of partitions for the offset commit topic. Since changing this after deployment is currently unsupported, we recommend using a higher setting for production (e.g., 100-200).
-offsets.topic.num.partitions={{ kafka_server.offsets_topic_num_partitions }}
+offsets.topic.num.partitions={{ kafka_server_config.offsets_topic_num_partitions }}
 {% endif %}
 
-{% if kafka_server.offsets_topic_retention_minutes %}
+{% if kafka_server_config.offsets_topic_retention_minutes %}
 # default: 1440
 # Offsets that are older than this age will be marked for deletion. The actual purge will occur when the log cleaner compacts the offsets topic.
-offsets.topic.retention.minutes={{ kafka_server.offsets_topic_retention_minutes }}
+offsets.topic.retention.minutes={{ kafka_server_config.offsets_topic_retention_minutes }}
 {% endif %}
 
-{% if kafka_server.offsets_retention_check_interval_ms %}
+{% if kafka_server_config.offsets_retention_check_interval_ms %}
 # default: 600000
 # The frequency at which the offset manager checks for stale offsets.
-offsets.retention.check.interval.ms={{ kafka_server.offsets_retention_check_interval_ms }}
+offsets.retention.check.interval.ms={{ kafka_server_config.offsets_retention_check_interval_ms }}
 {% endif %}
 
-{% if kafka_server.offsets_topic_replication_factor %}
+{% if kafka_server_config.offsets_topic_replication_factor %}
 # The replication factor for the offset commit topic. A higher setting (e.g., three or four) is recommended in order to ensure higher availability. If the offsets topic is created when fewer brokers than the replication factor then the offsets topic will be created with fewer replicas.
-offsets.topic.replication.factor={{ kafka_server.offsets_topic_replication_factor }}
+offsets.topic.replication.factor={{ kafka_server_config.offsets_topic_replication_factor }}
 {% endif %}
 
-{% if kafka_server.offsets_topic_segment_bytes %}
+{% if kafka_server_config.offsets_topic_segment_bytes %}
 # default: 104857600
 # Segment size for the offsets topic. Since it uses a compacted topic, this should be kept relatively low in order to facilitate faster log compaction and loads.
-offsets.topic.segment.bytes={{ kafka_server.offsets_topic_segment_bytes }}
+offsets.topic.segment.bytes={{ kafka_server_config.offsets_topic_segment_bytes }}
 {% endif %}
 
-{% if kafka_server.offsets_load_buffer_size %}
+{% if kafka_server_config.offsets_load_buffer_size %}
 # default: 5242880
 # An offset load occurs when a broker becomes the offset manager for a set of consumer groups (i.e., when it becomes a leader for an offsets topic partition). This setting corresponds to the batch size (in bytes) to use when reading from the offsets segments when loading offsets into the offset manager's cache.
-offsets.load.buffer.size={{ kafka_server.offsets_load_buffer_size }}
+offsets.load.buffer.size={{ kafka_server_config.offsets_load_buffer_size }}
 {% endif %}
 
-{% if kafka_server.offsets_commit_required_acks %}
+{% if kafka_server_config.offsets_commit_required_acks %}
 # default: -1
 # The number of acknowledgements that are required before the offset commit can be accepted. This is similar to the producer's acknowledgement setting. In general, the default should not be overridden.
-offsets.commit.required.acks={{ kafka_server.offsets_commit_required_acks }}
+offsets.commit.required.acks={{ kafka_server_config.offsets_commit_required_acks }}
 {% endif %}
 
-{% if kafka_server.offsets_commit_timeout_ms %}
+{% if kafka_server_config.offsets_commit_timeout_ms %}
 # default: 5000
 # The offset commit will be delayed until this timeout or the required number of replicas have received the offset commit. This is similar to the producer request timeout.
-offsets.commit.timeout.ms={{ kafka_server.offsets_commit_timeout_ms }}
+offsets.commit.timeout.ms={{ kafka_server_config.offsets_commit_timeout_ms }}
 {% endif %}
 
 {% endif %}
 
-{% for key, value in kafka_server.misc.iteritems() -%}
+{% for key, value in kafka_server_config.misc.iteritems() -%}
 {{key}}={{value}}
 {% endfor -%}


### PR DESCRIPTION
In modern versions of Ansible (I'm using version 2.6.1, which this bug applies to) there is new behavior of `set_fact`, where `set_fact` no longer overrides role variables (see [Ansible 22025](https://github.com/ansible/ansible/issues/22025) for a discussion of this). When passing in the role variable `kafka_server` via a playbook, this variable will not be merged properly with `kafka_server_defaults`, since the result of the merge is re-assigned back to `kafka_server`. This will cause problems when executing the role, as `kafka_server` will likely not contain much of the needed properties. As an example, try running the playbook:

```
- hosts: [all]
  become: yes
  roles:
    - {
      role: "ansible-kafka",
      kafka_hosts: ['xxx', 'yyy'],
      kafka_zookeeper_hosts: ['zzz'],
      kafka_version: 0.11.0.2,
      kafka_scala_serverion: 2.10,
      kafka_java_version: "openjdk-8-jre",
      kafka_server: {
        host_name: "newhostname"
      }
    }
```

The result will be an error of the form:

`FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'port'\n\nThe error appears to have been in '/home/bradleysheppard/Dev/AnsibleKafka/ansible-kafka/tasks/kafka-cfg.yml': line 31, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Generate the kafka hosts connection string\"\n  ^ here\n"}`

The fix involves not reassigning the result of the merge back to `kafka_server`, but instead using a new variable, which I have called `kafka_server_config`.