### PR TITLE
iteritems not working for dict in py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ python: 2.7
 
 env:
   matrix:
-  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
   - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1 kafka_generate_broker_id=false"
-  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
+  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"
   - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1"
+  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"
 
 before_install:
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ python: 2.7
 
 env:
   matrix:
-  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1 kafka_generate_broker_id=false"
   - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"
-  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1"
+  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.1.1"
   - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"
+  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.1.1"
 
 before_install:
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ sudo: required
 dist: trusty
 
 language: python
-python: 2.7
+python:
+  - 2.7
+  - 3.6
 
 env:
-  matrix:
   - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"
   - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.1.1"
   - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ kafka_zookeeper_port: 2181
 kafka_hosts: # <-- must be overridden further up the chain
 # e.g. [ 'srvr1', 'srvr2' ]
 
-kafka_version: "0.11.0.2"
+kafka_version: "1.0.2"
 
 kafka_scala_version: "2.11"
 # NB: 2.11 is recommended at https://kafka.apache.org/downloads.html.

--- a/templates/etc/defaults/kafka.j2
+++ b/templates/etc/defaults/kafka.j2
@@ -1,6 +1,6 @@
 KAFKA_HEAP_OPTS='{{ kafka_heap_opts }}'
 LOG_DIR='{{ kafka_log_dir }}'
 
-{% for key, value in kafka_environment.iteritems() %}
+{% for key, value in kafka_environment.items() %}
 {{key}}={{value}}
 {% endfor %}

--- a/templates/usr/local/kafka/config/server.properties.j2
+++ b/templates/usr/local/kafka/config/server.properties.j2
@@ -517,6 +517,6 @@ offsets.commit.timeout.ms={{ kafka_server.offsets_commit_timeout_ms }}
 
 {% endif %}
 
-{% for key, value in kafka_server.misc.iteritems() -%}
+{% for key, value in kafka_server.misc.items() -%}
 {{key}}={{value}}
 {% endfor -%}


### PR DESCRIPTION
There is some error if I am using ansible with py3
```
TASK [kafka : Render and write out kafka configuration files] ***********************
task path: /Users/lili/Research/Dev/playbooks/roles/kafka/tasks/kafka-cfg.yml:38
failed: [bcart01] (item=server.properties) => {
    "changed": false,
    "item": "server.properties",
    "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"
}
```

This fix should work for both py2 and py3.