### PR TITLE
Update kafka default version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ python: 2.7
 
 env:
   matrix:
-  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
-  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1 kafka_generate_broker_id=false"
-  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=0.11.0.2"
-  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=1.0.1"
+  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version="2.1.1"
+  - ANSIBLE_VERSION=2.2.3.0 ANSIBLE_EXTRA_VARS="kafka_version=2.11 kafka_generate_broker_id=false"
+  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version="2.1.1"
+  - ANSIBLE_VERSION=2.4.2.0 ANSIBLE_EXTRA_VARS="kafka_version=2.11"
 
 before_install:
 - sudo apt-get update -qq

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ kafka_zookeeper_port: 2181
 kafka_hosts: # <-- must be overridden further up the chain
 # e.g. [ 'srvr1', 'srvr2' ]
 
-kafka_version: "0.11.0.2"
+kafka_version: "2.1.1"
 
 kafka_scala_version: "2.11"
 # NB: 2.11 is recommended at https://kafka.apache.org/downloads.html.


### PR DESCRIPTION
As the version 0.11.0.2 is now unavailable, the default version should be updated to 0.11.0.3.
For available versions see http://apache.mirrors.tds.net/kafka/